### PR TITLE
Fix typo in minispy.vcxproj

### DIFF
--- a/MiniFSWatcherDriver/minispy.vcxproj
+++ b/MiniFSWatcherDriver/minispy.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -81,13 +81,13 @@
     <ClInclude Include="mspyKern.h" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <TargetName>minfifswatcher</TargetName>
+    <TargetName>minifswatcher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>minifswatcher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>minfifswatcher</TargetName>
+    <TargetName>minifswatcher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>minifswatcher</TargetName>


### PR DESCRIPTION
Due to this two typos, the output filenames are slightly wrong. Windows would refuse to load the driver.